### PR TITLE
make allvalues/allsyms listings stable

### DIFF
--- a/lib/Constant/Generate.pm
+++ b/lib/Constant/Generate.pm
@@ -239,11 +239,11 @@ sub import {
 	
 	if($listname) {
 		my %tmp = reverse %symhash;
-		_gen_constant($reqpkg, $listname, keys %tmp);
+		_gen_constant($reqpkg, $listname, sort { $a <=> $b } keys %tmp);
 		push @symlist, $listname;
 	}
 	if($symsname) {
-		_gen_constant($reqpkg, $symsname, keys %symhash);
+		_gen_constant($reqpkg, $symsname, sort { $symhash{$a} <=> $symhash{$b} } keys %symhash);
 		push @symlist, $symsname;
 	}
 	

--- a/t/03-listings.t
+++ b/t/03-listings.t
@@ -6,24 +6,7 @@ use Constant::Generate [qw(
     FOO BAR BAZ
 )], -allvalues => 'MYVALS', -allsyms => 'MYSYMS';
 
-my %expected_values = (
-    0 => undef,
-    1 => undef,
-    2 => undef
-);
-
-my %expected_syms = (
-    'FOO' => undef,
-    'BAR' => undef,
-    'BAZ' => undef,
-);
-
-$expected_values{$_} = $_ for (MYVALS);
-$expected_syms{$_} = $_ for (MYSYMS);
-
-ok(!grep(!defined $_, values %expected_values),
-   "allvalues");
-ok(!grep(!defined $_, values %expected_syms),
-   "allsyms");
+is_deeply [ MYVALS ] => [ 0, 1, 2 ],        'allvalues';
+is_deeply [ MYSYMS ] => [qw/ FOO BAR BAZ/], 'allsyms';
 
 done_testing();


### PR DESCRIPTION
This patch makes allvalues and allsyms return
their values ordered following the values of the constants.

This should fill the needs of issue #4.